### PR TITLE
Multiple files

### DIFF
--- a/recipe_checker.py
+++ b/recipe_checker.py
@@ -169,7 +169,7 @@ def main():
     recipes = args.recipe[0]
     verbosity = args.verbose
 
-    for recpie in recipes:
+    for recipe in recipes:
         r = RecipeChecker(recipe, verbosity)
         r.load_recipe()
         if r.is_recipe:

--- a/recipe_checker.py
+++ b/recipe_checker.py
@@ -162,21 +162,24 @@ class RecipeChecker():
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--verbose", action="count", default=0)
-    parser.add_argument("recipe", type=str, help="a valid autopkg recipe file")
+    parser.add_argument("recipe", action='append', nargs='+', type=str,
+                         help="at least one autopkg recipe file")
     args = parser.parse_args()
 
-    recipe = args.recipe
+    recipes = args.recipe[0]
     verbosity = args.verbose
-    r = RecipeChecker(recipe, verbosity)
-    r.load_recipe()
-    if r.is_recipe:
-        r.check_recipe()
-    print r.report
-    if r.subreport != []:
-        for line in r.subreport:
-            print line
-    else:
-        print "==> Recipe checks passed!"
+
+    for recpie in recipes:
+        r = RecipeChecker(recipe, verbosity)
+        r.load_recipe()
+        if r.is_recipe:
+            r.check_recipe()
+        print r.report
+        if r.subreport != []:
+            for line in r.subreport:
+                print line
+        else:
+            print "==> Recipe checks passed!"
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Update recipe checker to allow multiple recipe files to be given on the command line.

Note: there must be at least one recipe file
